### PR TITLE
remove key when calculating digest

### DIFF
--- a/luajwtjitsi.lua
+++ b/luajwtjitsi.lua
@@ -9,7 +9,7 @@ local function signRS (data, key, algo)
 	if privkey == nil then
 		return nil, 'Not a private PEM key'
 	else
-		return privkey:sign(digest.new(key, algo):update(data))
+		return privkey:sign(digest.new(algo):update(data))
 	end
 end
 
@@ -18,7 +18,7 @@ local function verifyRS (data, signature, key, algo)
 	if pubkey == nil then
 		return nil, 'Not a public PEM key'
 	else
-		return pubkey:verify(signature, digest.new(key, algo):update(data))
+		return pubkey:verify(signature, digest.new(algo):update(data))
 	end
 end
 


### PR DESCRIPTION
There is no need a key when calculating digest. Its fixing eror when using JWT with alg: RS256